### PR TITLE
Update Lodash Due to Vulnerability Audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@pawelgalazka/cli-args": "1.1.3",
     "@pawelgalazka/middleware": "1.0.0",
     "chalk": "2.4.2",
-    "lodash": "4.17.11"
+    "lodash": "4.17.12"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",


### PR DESCRIPTION
As noted in the issues, there is a high vulnerability alert due to an outdated version of Lodash. This is also affecting the task runner project. This PR addresses that concern.